### PR TITLE
Update deployment.yaml

### DIFF
--- a/templates/nserver/deployment.yaml
+++ b/templates/nserver/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               name: nserver-template
             - mountPath: /app/etc/script
               name: nserver-script
-      hostname: nserver
+      # hostname: nserver
       restartPolicy: Always
       volumes:
         - name: nserver-config


### PR DESCRIPTION
nserver设置多副本时候，指定hostname会导致多副本的hostname相同，导致规则的分配出现问题