### PR TITLE
fixed(database): add subPath for my.cnf  #54

### DIFF
--- a/templates/database/statefulset.yaml
+++ b/templates/database/statefulset.yaml
@@ -73,6 +73,7 @@ spec:
         - mountPath: /var/lib/mysql/
           name: database-data
         - mountPath: /etc/my.cnf
+          subPath: my.cnf
           name: database-config
         - mountPath: /docker-entrypoint-initdb.d
           name: database-initdb-config


### PR DESCRIPTION
修复数据库编排中的 `configmap/database-config` 错误的是使用文件夹的方式挂载`my.cnf`.造成容器启动时报错

```
Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/kubelet/pods/7469f279-7f96-41a7-a0ba-dcf58367cfea/volumes/kubernetes.io~configmap/database-config" to rootfs at "/etc/my.cnf": mount /var/lib/kubelet/pods/7469f279-7f96-41a7-a0ba-dcf58367cfea/volumes/kubernetes.io~configmap/database-config:/etc/my.cnf (via /proc/self/fd/6), flags: 0x5001: not a directory: unknown
```
