### PR TITLE
fixed(categraf): Empty docker_socket when kubernetes runtime is not d…

### DIFF
--- a/templates/categraf/daemonset.yaml
+++ b/templates/categraf/daemonset.yaml
@@ -96,8 +96,10 @@ spec:
               name: input-net
             - mountPath: /etc/categraf/conf/input.netstat
               name: input-netstat
+            {{- if and ( eq .Values.categraf.type "internal") ( .Values.categraf.internal.docker_socket) }}
             - mountPath: /etc/categraf/conf/input.docker
               name: input-docker
+            {{- end }}
             - mountPath: /etc/categraf/conf/input.kubernetes
               name: input-kubernetes
             - mountPath: /etc/categraf/conf/input.prometheus
@@ -118,8 +120,10 @@ spec:
             - mountPath: /hostfs
               name: hostrofs
               readOnly: true
+            {{- if and ( eq .Values.categraf.type "internal") ( .Values.categraf.internal.docker_socket) }}
             - name: docker-socket
               mountPath: {{ trimPrefix "unix://" .Values.categraf.internal.docker_socket }}
+            {{- end }}
       volumes:
         - name: categraf-config
           configMap:
@@ -147,9 +151,11 @@ spec:
         - name: input-netstat
           configMap:
             name: input-netstat
+        {{- if and ( eq .Values.categraf.type "internal") ( .Values.categraf.internal.docker_socket) }}
         - name: input-docker
           configMap:
             name: input-docker
+        {{- end }}
         - name: input-kubernetes
           configMap:
             name: input-kubernetes
@@ -177,8 +183,10 @@ spec:
         - name: hostroutmp
           hostPath:
             path: /var/run/utmp
+        {{- if and ( eq .Values.categraf.type "internal") ( .Values.categraf.internal.docker_socket) }}
         - name: docker-socket
           hostPath:
             path: {{ trimPrefix "unix://" .Values.categraf.internal.docker_socket }}
             type: Socket
+        {{- end }}
 {{- end -}}

--- a/templates/categraf/docker.yaml
+++ b/templates/categraf/docker.yaml
@@ -15,11 +15,13 @@
 #
 */}}
 {{- if eq .Values.categraf.type "internal" -}}
+{{- if .Values.categraf.internal.docker_socket -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: input-docker
 data:
 {{ (.Files.Glob "categraf/conf/input.docker/*.toml").AsConfig | indent 2 }}
+{{- end -}}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -198,6 +198,9 @@ categraf:
     tolerations: []
     affinity: {}
     priorityClassName:
+    ## Parm: categraf.internal.docker_socket  Desc: the path of docker socket on kubelet node.
+    ## "unix:///var/run/docker.sock" is default, if your kubernetes runtime is container or others, empty this variable.
+    ## docker_socket: ""
     docker_socket: unix:///var/run/docker.sock
   external:
     host: "192.168.0.3"


### PR DESCRIPTION
此 PR 的描述在 https://github.com/flashcatcloud/n9e-helm/issues/61