### PR TITLE
修复webapi及server不识别nodeselector及污点容忍的问题

### DIFF
--- a/templates/nserver/deployment.yaml
+++ b/templates/nserver/deployment.yaml
@@ -78,4 +78,16 @@ spec:
         - name: nserver-script
           configMap:
             name: nserver-script
+    {{- with .Values.nserver.internal.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.nserver.internal.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.nserver.internal.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- end -}}

--- a/templates/nwebapi/deployment.yaml
+++ b/templates/nwebapi/deployment.yaml
@@ -78,4 +78,16 @@ spec:
         - name: nwebapi-dashboards
           configMap:
             name: nwebapi-dashboards
+    {{- with .Values.nwebapi.internal.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.nwebapi.internal.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.nwebapi.internal.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- end -}}


### PR DESCRIPTION
使用helm部署时，即使修改了values.yaml里webapi和server这两个模块的nodeselector选项及tolerations选项，仍然无法被chart正确识别到，下方代码修改了chart模板，修复了此问题