### PR TITLE
fix: prometheus targets mistake

### DIFF
--- a/templates/prometheus/configmap.yaml
+++ b/templates/prometheus/configmap.yaml
@@ -24,7 +24,7 @@ data:
     [
       {
         "targets": [
-          "n9e: {{ template  "nightingale.n9e.servicePort" . }}"
+          "nightingale-center:{{ template  "nightingale.n9e.servicePort" . }}"
         ]
       }
     ]


### PR DESCRIPTION
### 问题：

我使用 Helm 部署服务后发现, 监控目标 n9e 准备失败报错如下

### 错误排查：

1. 排查 kubernetes svc 后发现, svc内并没有创造名称为 n9e 的 svc 导致连接失败
2. 并且 prometheus 在报错格式错误

<img width="1511" alt="image" src="https://github.com/flashcatcloud/n9e-helm/assets/102201557/a4b1028b-9cb7-4fa4-baa2-bd7ce71710fd">

修改后格式和 svc 名称后恢复
<img width="1511" alt="image" src="https://github.com/flashcatcloud/n9e-helm/assets/102201557/1a9bff0f-df7a-419b-bfb7-e441ad902661">
