### PR TITLE
chore: add helm chart action

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,61 @@
+name: Release Chart
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  USERNAME: n9e
+
+permissions: {}
+jobs:
+  release-chart:
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$USERNAME"
+          git config user.email "$USERNAME@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          mark_as_latest: false
+          charts_dir: .
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"
+          CR_GENERATE_RELEASE_NOTES: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: $USERNAME
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/$USERNAME/charts"
+          done


### PR DESCRIPTION
利用 github page 实现 helm repository 效果。

利用 action 将 helm chart 资源推送到 `n9e/n9e.github.io` github page 仓库。

前提：需要在 `flashcatcloud/n9e-helm` 仓库添加 `n9e` 账号 github token。

效果：
```
helm repo add n9e https://n9e.github.io/charts/
```

https://github.com/flashcatcloud/n9e-helm/issues/104