### PR TITLE
feat: 升级 n9e 至 v8.5.0，新增可选 VictoriaMetrics 写入端，时区统一可配置

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -29,7 +29,7 @@ sources:
 maintainers:
 - email: contact-us@flashcat.cloud
   name: flashcatcloud
-version: 0.2.11
+version: 0.3.0
 apiVersion: v1
-appVersion: 8.0.0-beta12
+appVersion: 8.5.0
 icon: https://raw.githubusercontent.com/flashcatcloud/n9e-helm/master/n9e-icon.png

--- a/categraf/conf/input.cadvisor/cadvisor.toml
+++ b/categraf/conf/input.cadvisor/cadvisor.toml
@@ -1,15 +1,15 @@
 # # collect interval
 # interval = 15
 
-[[instances]]
-# kubelete metrics & cadvisor
-type = "kubelet"
-url = "https://127.0.0.1:10250/metrics/cadvisor"
-url_label_key = "instance"
-url_label_value = "{{.Host}}"
-bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-ignore_label_keys = ["id","name", "container_label*"]
-# 只采集那些label key, 建议保持为空，采集所有的label。 优先级高于ignore_label_keys。
-# choose_label_keys = ["*"]
-use_tls = true
-insecure_skip_verify = true
+# [[instances]]
+# # kubelete metrics & cadvisor
+# type = "kubelet"
+# url = "https://127.0.0.1:10250/metrics/cadvisor"
+# url_label_key = "instance"
+# url_label_value = "{{.Host}}"
+# bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+# ignore_label_keys = ["id","name", "container_label*"]
+# # 只采集那些label key, 建议保持为空，采集所有的label。 优先级高于ignore_label_keys。
+# # choose_label_keys = ["*"]
+# use_tls = true
+# insecure_skip_verify = true

--- a/categraf/conf/input.cadvisor/cadvisor.toml
+++ b/categraf/conf/input.cadvisor/cadvisor.toml
@@ -2,7 +2,7 @@
 # interval = 15
 
 # [[instances]]
-# # kubelete metrics & cadvisor
+# # kubelet metrics & cadvisor
 # type = "kubelet"
 # url = "https://127.0.0.1:10250/metrics/cadvisor"
 # url_label_key = "instance"

--- a/categraf/conf/input.prometheus/prometheus.toml
+++ b/categraf/conf/input.prometheus/prometheus.toml
@@ -2,7 +2,7 @@
 # interval = 15
 
 [[instances]]
-# kubelete metrics
+# kubelet metrics
 urls = ["https://127.0.0.1:10250/metrics"]
 bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 use_tls = true
@@ -10,4 +10,17 @@ insecure_skip_verify = true
 url_label_key = "instance"
 url_label_value = "{{.Host}}"
 # if you use dashboards, do not delete this label
-labels = {job="categraf"}
+labels = { job = "categraf" }
+
+[[instances]]
+# cadvisor metrics
+urls = ["https://127.0.0.1:10250/metrics/cadvisor"]
+bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+use_tls = true
+insecure_skip_verify = true
+url_label_key = "instance"
+url_label_value = "{{.Host}}"
+ignore_label_keys = ["id", "name", "container_label*"]
+# if you use dashboards, do not delete this label
+labels = { job = "categraf" }
+

--- a/templates/categraf/daemonset.yaml
+++ b/templates/categraf/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
       containers:
         - env:
             - name: TZ
-              value: Asia/Shanghai
+              value: UTC
             - name: HOSTNAME
               valueFrom:
                 fieldRef:
@@ -103,7 +103,7 @@ spec:
             - mountPath: /etc/categraf/conf/input.kubernetes
               name: input-kubernetes
             - mountPath: /etc/categraf/conf/input.prometheus
-              name: input-kubelet-metrics
+              name: input-prometheus
             - mountPath: /etc/categraf/conf/input.cadvisor
               name: input-cadvisor
             - mountPath: /etc/categraf/conf/input.kernel
@@ -161,9 +161,9 @@ spec:
         - name: input-kubernetes
           configMap:
             name: input-kubernetes
-        - name: input-kubelet-metrics
+        - name: input-prometheus
           configMap:
-            name: input-kubelet-metrics
+            name: input-prometheus
         - name: input-cadvisor
           configMap:
             name: input-cadvisor

--- a/templates/categraf/daemonset.yaml
+++ b/templates/categraf/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
       containers:
         - env:
             - name: TZ
-              value: UTC
+              value: {{ .Values.tz | default "UTC" | quote }}
             - name: HOSTNAME
               valueFrom:
                 fieldRef:

--- a/templates/categraf/prometheus.yaml
+++ b/templates/categraf/prometheus.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: input-kubelet-metrics
+  name: input-prometheus
 data:
 {{ (.Files.Glob "categraf/conf/input.prometheus/*.toml").AsConfig | indent 2 }}
 {{- end -}}

--- a/templates/database/statefulset.yaml
+++ b/templates/database/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               name: "{{ template "nightingale.database" . }}"
         env:
           - name: TZ
-            value: Asia/Shanghai
+            value: UTC
 {{- if .Values.database.internal.resources }}
         resources:
 {{ toYaml .Values.database.internal.resources | indent 10 }}

--- a/templates/database/statefulset.yaml
+++ b/templates/database/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               name: "{{ template "nightingale.database" . }}"
         env:
           - name: TZ
-            value: UTC
+            value: {{ .Values.tz | default "UTC" | quote }}
 {{- if .Values.database.internal.resources }}
         resources:
 {{ toYaml .Values.database.internal.resources | indent 10 }}

--- a/templates/n9e/conf-cm.yaml
+++ b/templates/n9e/conf-cm.yaml
@@ -128,6 +128,23 @@ data:
     MaxConnsPerHost = 0
     MaxIdleConns = 100
     MaxIdleConnsPerHost = 100
+{{- if .Values.n9e.victoriaMetrics.enabled }}
+
+    [[Pushgw.Writers]]
+    Url = "{{ .Values.n9e.victoriaMetrics.url }}"
+    BasicAuthUser = "{{ .Values.n9e.victoriaMetrics.basicAuthUser }}"
+    BasicAuthPass = "{{ .Values.n9e.victoriaMetrics.basicAuthPass }}"
+    Headers = ["X-From", "n9e"]
+    Timeout = 10000
+    DialTimeout = 3000
+    TLSHandshakeTimeout = 30000
+    ExpectContinueTimeout = 1000
+    IdleConnTimeout = 90000
+    KeepAlive = 30000
+    MaxConnsPerHost = 0
+    MaxIdleConns = 100
+    MaxIdleConnsPerHost = 100
+{{- end }}
     [Ibex]
     Enable = false
     RPCListen = "0.0.0.0:{{ template "nightingale.n9e.ibexPort" . }}"

--- a/templates/n9e/conf-cm.yaml
+++ b/templates/n9e/conf-cm.yaml
@@ -131,9 +131,9 @@ data:
 {{- if .Values.n9e.victoriaMetrics.enabled }}
 
     [[Pushgw.Writers]]
-    Url = "{{ .Values.n9e.victoriaMetrics.url }}"
-    BasicAuthUser = "{{ .Values.n9e.victoriaMetrics.basicAuthUser }}"
-    BasicAuthPass = "{{ .Values.n9e.victoriaMetrics.basicAuthPass }}"
+    Url = {{ .Values.n9e.victoriaMetrics.url | quote }}
+    BasicAuthUser = {{ .Values.n9e.victoriaMetrics.basicAuthUser | quote }}
+    BasicAuthPass = {{ .Values.n9e.victoriaMetrics.basicAuthPass | quote }}
     Headers = ["X-From", "n9e"]
     Timeout = 10000
     DialTimeout = 3000

--- a/templates/n9e/deployment.yaml
+++ b/templates/n9e/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: GIN_MODE
               value: release
             - name: TZ
-              value: UTC
+              value: {{ .Values.tz | default "UTC" | quote }}
           image: {{ .Values.n9e.internal.image.repository }}:{{ .Values.n9e.internal.image.tag }}
           name: center
           ports:

--- a/templates/n9e/deployment.yaml
+++ b/templates/n9e/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: GIN_MODE
               value: release
             - name: TZ
-              value: Asia/Shanghai
+              value: UTC
           image: {{ .Values.n9e.internal.image.repository }}:{{ .Values.n9e.internal.image.tag }}
           name: center
           ports:

--- a/templates/prometheus/statefulset.yaml
+++ b/templates/prometheus/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           - --query.lookback-delta=2m
         env:
           - name: TZ
-            value: Asia/Shanghai
+            value: UTC
         image: {{ .Values.prometheus.internal.image.repository }}:{{ .Values.prometheus.internal.image.tag }}
         name: prometheus
         ports:

--- a/templates/prometheus/statefulset.yaml
+++ b/templates/prometheus/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           - --query.lookback-delta=2m
         env:
           - name: TZ
-            value: UTC
+            value: {{ .Values.tz | default "UTC" | quote }}
         image: {{ .Values.prometheus.internal.image.repository }}:{{ .Values.prometheus.internal.image.tag }}
         name: prometheus
         ports:

--- a/values.yaml
+++ b/values.yaml
@@ -217,14 +217,14 @@ n9e:
     automountServiceAccountToken: false
     image:
       repository: flashcatcloud/nightingale
-      tag: 8.0.0-beta.11
+      tag: 8.5.0
     resources: {}
     #  requests:
     #    memory: 512Mi
     #    cpu: 1000m
-    nodeSelector: { }
-    tolerations: [ ]
-    affinity: { }
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
     priorityClassName:
     ibexEnable: false
     ibexPort: "20090"
@@ -233,4 +233,9 @@ n9e:
     port: "17000"
     ibexEnable: false
     ibexPort: "20090"
-  podAnnotations: { }
+  victoriaMetrics:
+    enabled: false
+    url: "http://victoria-metrics:8428/api/v1/write"
+    basicAuthUser: ""
+    basicAuthPass: ""
+  podAnnotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -93,6 +93,10 @@ updateStrategy:
 
 logLevel: info
 
+# Container timezone applied to all internal components (n9e, database, prometheus, categraf).
+# Set to e.g. "Asia/Shanghai" if you need local timestamps inside containers.
+tz: UTC
+
 caSecretName: ""
 
 secretKey: "not-a-secure-key"


### PR DESCRIPTION
## 概述

本 PR 包含三处独立但互相关联的改进，并已根据 Copilot code review 反馈做了进一步打磨：

1. **升级 n9e 至 v8.5.0**（上游最新稳定版，新增 VictoriaLogs 数据源与告警规则支持）。Chart 版本 0.2.11 → 0.3.0，appVersion → 8.5.0。
2. **新增可选的 VictoriaMetrics 写入端**，在 `values.yaml` 中通过 `n9e.victoriaMetrics.enabled` 开关控制。默认关闭，对现有部署零影响。
3. **统一所有模板的时区，并通过 `.Values.tz` 暴露为可配置项**（默认 `UTC`）。同时将 categraf 的 kubelet 与 cadvisor 抓取合并到统一的 `input.prometheus` 配置下（`kubelet-metrics` ConfigMap 重命名为 `input-prometheus`；`input.cadvisor` 作为注释占位保留以兼容自定义覆盖）。

## 关联 Issue

- Closes #141 — `values.yaml` 不再需要手动修改 `Pushgw.Writers` 来追加外部时序库（如 VictoriaMetrics）写入端。
- Addresses #78（写入侧）— chart 原生支持 VM 作为写入目标；读取/存储侧将另起 PR 处理。
- Related #132 — chart appVersion 现已追到上游稳定版 v8.5.0，不再停留在 beta。

## 改动详情

### `values.yaml`

- `n9e.internal.image.tag`：`8.0.0-beta.11` → `8.5.0`
- 新增顶层 `tz` 配置，作用于全部内置组件容器：
  ```yaml
  # Container timezone applied to all internal components (n9e, database, prometheus, categraf).
  # Set to e.g. "Asia/Shanghai" if you need local timestamps inside containers.
  tz: UTC
  ```
- 新增 `n9e.victoriaMetrics` 配置块：
  ```yaml
  n9e:
    victoriaMetrics:
      enabled: false
      url: "http://victoria-metrics:8428/api/v1/write"
      basicAuthUser: ""
      basicAuthPass: ""
  ```

### `Chart.yaml`

- `version`：0.2.11 → 0.3.0
- `appVersion`：8.0.0-beta12 → 8.5.0

### `templates/n9e/conf-cm.yaml`

- 当 `n9e.victoriaMetrics.enabled=true` 时，条件性追加一段 `[[Pushgw.Writers]]`。原有的 prometheus 写入端保持不变，VM 为追加形式（双写），不替换。
- 渲染时使用 Helm 的 `quote` 过滤器对 `Url` / `BasicAuthUser` / `BasicAuthPass` 进行转义，避免值中含有 `"` 或 `\` 时破坏 TOML 语法。

### 时区配置可覆盖

应用到以下模板，TZ env 统一改为引用 `.Values.tz`，默认 `UTC`：

```yaml
- name: TZ
  value: {{ .Values.tz | default "UTC" | quote }}
```

- `templates/n9e/deployment.yaml`
- `templates/database/statefulset.yaml`
- `templates/prometheus/statefulset.yaml`
- `templates/categraf/daemonset.yaml`

> redis / nginx 模板原本就没有 TZ env，本 PR 不新增，以避免改变这两个容器的默认时间戳行为。

### Categraf 的 prometheus / cadvisor 配置合并

- 重命名 `templates/categraf/kubelet-metrics.yaml` → `templates/categraf/prometheus.yaml`；ConfigMap 名称 `input-kubelet-metrics` → `input-prometheus`。
- 将 cadvisor 抓取端点（`/metrics/cadvisor`）合并到 `categraf/conf/input.prometheus/prometheus.toml`，作为第二个 `[[instances]]` 条目，统一使用 prometheus input 插件采集。
- `categraf/conf/input.cadvisor/cadvisor.toml` **全部内容注释**保留，避免破坏挂载路径与用户自定义覆盖；`input-cadvisor` ConfigMap 及其在 `daemonset.yaml` 中的挂载维持原样。
- 顺手修正了 `cadvisor.toml` 注释中的 `kubelete` → `kubelet` 拼写。

## Code review 反馈处理（Copilot）

| # | Copilot 建议 | 处理 |
| --- | --- | --- |
| 1 | TOML 字符串手动加引号（`Url = "{{ ... }}"`）易破坏格式 | ✅ 改用 `quote` 过滤器，正确转义 `"` / `\` |
| 2 | `basicAuthPass` 明文进 ConfigMap，建议 Secret 化 | 🟡 暂不处理 —— 与现 chart 整体安全模型一致（`database.internal.password`、`secretKey`、各种 external password 均直接写在 values.yaml）。把 `n9e-config` 整体由 ConfigMap 切换为 Secret 是更系统的方案，但属于与本 PR 主题无关的独立变更，留待后续 PR |
| 3 | `TZ` 硬编码 `UTC`，无 chart value 可覆盖 | ✅ 引入顶层 `.Values.tz`，默认 `UTC`，4 个模板统一引用 |
| 4 | `cadvisor.toml` 注释 `kubelete` 拼写 | ✅ 已修正为 `kubelet` |

## 向后兼容性说明

- **VictoriaMetrics 写入端** 默认 `enabled: false`，现有部署行为完全一致。
- **时区变更**：原本运行 CST 的容器升级后将切换为 UTC。如业务依赖容器内 CST 本地时间戳，可在 values 中设置 `tz: "Asia/Shanghai"` 维持原行为，无需再覆盖 `TZ` 环境变量。
- **ConfigMap 重命名**（`input-kubelet-metrics` → `input-prometheus`）对外部直接引用旧名称的场景属于破坏性变更；Helm 升级会自动删除旧 CM 并创建新 CM，由于 daemonset 中 volume 名称同步变更，categraf pod 会触发滚动重启。
- **`cadvisor.toml` 注释化**：categraf 仍会挂载 `/etc/categraf/conf/input.cadvisor/`，但该目录不会生成任何抓取实例。等价的 cadvisor 端点改由 prometheus input 采集。

## 测试方案

- [x] `helm template .` 默认渲染：4 个组件的 TZ env 均为 `"UTC"`
- [x] `helm template . --set tz=Asia/Shanghai` 覆盖渲染：4 个组件的 TZ env 均为 `"Asia/Shanghai"`
- [x] `helm template . --set n9e.victoriaMetrics.enabled=true --set n9e.victoriaMetrics.basicAuthPass='p"ass'` 渲染结果中 `BasicAuthPass = "p\"ass"`，`"` 正确转义
- [x] `helm template . --set n9e.victoriaMetrics.enabled=false`（默认）渲染结果中不包含 VM 写入端
- [x] 全仓库 `grep` 确认无残留的 `kubelete` 拼写
- [ ] 在 kind / k3d 集群上全新 `helm install`：n9e center 正常启动，prometheus 与 VM（若启用）均能收到来自 `/api/v1/push` 的指标
- [ ] 从上一版本 chart 升级：pod 干净滚动重启，旧 `input-kubelet-metrics` ConfigMap 被新 `input-prometheus` 替换
- [ ] categraf 仍能采集到 kubelet 与 cadvisor 指标（通过查询 `kubelet_*` 与 `container_*` 时间序列验证）
